### PR TITLE
Add container names to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@
 version: "3"
 services:
   db:
+    container_name: db
     image: postgres
     restart: always
     environment:
@@ -26,6 +27,7 @@ services:
       - ./dev:/var/lib/postgresql/data:rw
       - ./dev/initdb:/docker-entrypoint-initdb.d
   web:
+    container_name: web
     image: ghcr.io/lolibrary/sakura-dev:latest
     # build:
     #   context: .


### PR DESCRIPTION
Small QoL change. Allows `docker exec` and `docker-compose` to use the same name for the container, instead of using auto generated names like `sakura_db_1`