### PR TITLE
Issue #24 - public closet and wishlist

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -28,8 +28,9 @@ class ProfileController extends Controller
     public function profile()
     {
         $user = Auth::user();
+        $isOwner = true;
 
-        return view('profile.index', compact('user'));
+        return view('profile.index', compact('user', 'isOwner'));
     }
 
     /**
@@ -72,6 +73,9 @@ class ProfileController extends Controller
             $user->password = Hash::make($validatedData['password']);
         }
 
+        $user->public_closet = $request->has('public_closet') == '1' ? '1' : '0';
+        $user->public_wishlist = $request->has('public_wishlist') == '1' ? '1' : '0';
+
         $user->save();
         
         return redirect('profile')->with('status', $status);
@@ -86,9 +90,8 @@ class ProfileController extends Controller
     public function closet(Request $request)
     {
         $user = Auth::user();
-        $items = $user->closet($request->input('order'))->paginate(24);
 
-        return view('profile.closet', compact('user', 'items'));
+        return redirect()->route('public_closet', ['username' => $user->username]);
     }
 
     /**
@@ -100,8 +103,6 @@ class ProfileController extends Controller
     public function wishlist(Request $request)
     {
         $user = Auth::user();
-        $items = $user->wishlist($request->input('order'))->paginate(24);
-
-        return view('profile.wishlist', compact('user', 'items'));
+        return redirect()->route('public_wishlist', ['username' => $user->username]);
     }
 }

--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 class PublicProfileController extends Controller
 {
     /**
-     * Construct a new Profile Controller.
+     * Construct a new Public Profile Controller.
      *
      * @return void
      */
@@ -18,7 +18,7 @@ class PublicProfileController extends Controller
 
 
     /**
-     * Get a user's closet (owned items).
+     * Get a given user's closet (owned items).
      *
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
@@ -39,7 +39,7 @@ class PublicProfileController extends Controller
     }
 
     /**
-     * Get a user's wishlist (favourited items).
+     * Get a given user's wishlist (favourited items).
      *
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response

--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PublicProfileController extends Controller
+{
+    /**
+     * Construct a new Profile Controller.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth.owner');
+    }
+
+
+    /**
+     * Get a user's closet (owned items).
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function closet(Request $request)
+    {
+        $requestedUser = $request->get('requestedUser');
+        $isOwner = $request->get('isOwner');
+
+        if (!$isOwner && !$requestedUser->public_closet) {
+            abort(404);
+        }
+
+        $items = $requestedUser->closet($request->input('order'))->paginate(24);
+
+        $user = $requestedUser;
+        return view('profile.closet', compact('user', 'items', 'isOwner'));
+    }
+
+    /**
+     * Get a user's wishlist (favourited items).
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function wishlist(Request $request)
+    {
+        $requestedUser = $request->get('requestedUser');
+        $isOwner = $request->get('isOwner');
+
+        if (!$isOwner && !$requestedUser->public_wishlist) {
+            abort(404);
+        }
+
+        $items = $requestedUser->wishlist($request->input('order'))->paginate(24);
+
+        $user = $requestedUser;
+        return view('profile.wishlist', compact('user', 'items', 'isOwner'));
+    }
+}

--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -28,7 +28,7 @@ class PublicProfileController extends Controller
         $requestedUser = $request->get('requestedUser');
         $isOwner = $request->get('isOwner');
 
-        if (!$isOwner && !$requestedUser->public_closet) {
+        if (empty($requestedUser) || (!$isOwner && !$requestedUser->public_closet)) {
             abort(404);
         }
 
@@ -49,7 +49,7 @@ class PublicProfileController extends Controller
         $requestedUser = $request->get('requestedUser');
         $isOwner = $request->get('isOwner');
 
-        if (!$isOwner && !$requestedUser->public_wishlist) {
+        if (empty($requestedUser) || (!$isOwner && !$requestedUser->public_wishlist)) {
             abort(404);
         }
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,6 +54,7 @@ class Kernel extends HttpKernel
     protected $routeMiddleware = [
         'auth' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'auth.owner' => \App\Http\Middleware\AllowOwnerOrPublicViewEnabled::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,7 +54,7 @@ class Kernel extends HttpKernel
     protected $routeMiddleware = [
         'auth' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
-        'auth.owner' => \App\Http\Middleware\AllowOwnerOrPublicViewEnabled::class,
+        'auth.owner' => \App\Http\Middleware\CheckIfOwnerIsLoggedIn::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,

--- a/app/Http/Middleware/AllowOwnerOrPublicViewEnabled.php
+++ b/app/Http/Middleware/AllowOwnerOrPublicViewEnabled.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class AllowOwnerOrPublicViewEnabled
+{
+    public function handle($request, Closure $next)
+    {
+        $currentUser = Auth::user();
+        $username = $request->route('username');
+        $requestedUser = User::where('username', $username)->firstOrFail();
+        $isOwner = (!empty($currentUser) && $currentUser->id == $requestedUser->id);
+        $request->attributes->add(['isOwner' => $isOwner, 'requestedUser' => $requestedUser]);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/AllowOwnerOrPublicViewEnabled.php
+++ b/app/Http/Middleware/AllowOwnerOrPublicViewEnabled.php
@@ -12,8 +12,11 @@ class AllowOwnerOrPublicViewEnabled
     {
         $currentUser = Auth::user();
         $username = $request->route('username');
-        $requestedUser = User::where('username', $username)->firstOrFail();
-        $isOwner = (!empty($currentUser) && $currentUser->id == $requestedUser->id);
+        $requestedUser = User::where('username', $username)->first();
+        $isOwner = (
+            !empty($currentUser) && !empty($requestedUser)
+            && $currentUser->id == $requestedUser->id
+        );
         $request->attributes->add(['isOwner' => $isOwner, 'requestedUser' => $requestedUser]);
 
         return $next($request);

--- a/app/Http/Middleware/CheckIfOwnerIsLoggedIn.php
+++ b/app/Http/Middleware/CheckIfOwnerIsLoggedIn.php
@@ -6,7 +6,7 @@ use App\Models\User;
 use Closure;
 use Illuminate\Support\Facades\Auth;
 
-class AllowOwnerOrPublicViewEnabled
+class CheckIfOwnerIsLoggedIn
 {
     public function handle($request, Closure $next)
     {

--- a/database/migrations/0056____add_public_wishlist_closet_flags.php
+++ b/database/migrations/0056____add_public_wishlist_closet_flags.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPublicWishlistClosetFlags extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->tinyInteger('public_wishlist')->unsigned()->default(0);
+            $table->tinyInteger('public_closet')->unsigned()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['public_wishlist', 'public_closet']);
+        });
+    }
+}

--- a/resources/lang/en/ui.php
+++ b/resources/lang/en/ui.php
@@ -41,6 +41,8 @@ return [
         'pw_reset_btn' => 'Send Password Reset Link',
         'pw_no_change' => "Leave this blank if you don't want to change your password.",
         'username_txt' => 'To change your username, <a class="text-info" href="#" data-toggle="tooltip" title="Changing username is not currently supported, sorry!">click here</a>',
+        'public_closet' => 'Make closet public?',
+        'public_wishlist' => 'Make wishlist public?',
     ],
 
     'blog' => [
@@ -77,8 +79,10 @@ return [
         'removed' => 'Removed ":item" from your wishlist',
         'stargazers' => 'Stargazer|Stargazers',
         'title' => 'Wishlist',
+        'owner_title' => ":user's Wishlist",
         'remove' => 'Remove from Wishlist',
         'empty' => 'There are no items in your wishlist.',
+        'empty_guest' => "There are no items in :user's wishlist",
         'add' => 'Why not <a href=":link">search for some items to add</a>?',
     ],
 
@@ -87,8 +91,10 @@ return [
         'removed' => 'Removed ":item" from your closet',
         'owners' => 'Owner|Owners',
         'title' => 'Closet',
+        'owner_title' => ":user's Closet",
         'remove' => 'Remove from Closet',
         'empty' => 'There are no items in your closet.',
+        'empty_guest' => "There are no items in :user's closet",
         'add' => 'Why not <a href=":link">search for some items to add</a>?',
     ],
 

--- a/resources/views/components/navbar/dropdown.blade.php
+++ b/resources/views/components/navbar/dropdown.blade.php
@@ -8,11 +8,11 @@
             <i class="fal fa-fw fa-user"></i> {{ __('Profile') }}
         </a>
 
-        <a class="dropdown-item" href="{{ route('wishlist') }}">
+        <a class="dropdown-item" href="{{ route('public_wishlist', ['username' => Auth::user()->username]) }}">
             <i class="fal fa-fw fa-star"></i> {{ __('Wishlist') }}
         </a>
 
-        <a class="dropdown-item" href="{{ route('closet') }}">
+        <a class="dropdown-item" href="{{ route('public_closet', ['username' => Auth::user()->username]) }}">
             <i class="fal fa-fw fa-tags"></i> {{ __('Closet') }}
         </a>
 

--- a/resources/views/profile/closet.blade.php
+++ b/resources/views/profile/closet.blade.php
@@ -1,4 +1,4 @@
-@extends('profile.layout', ['title' => __('ui.closet.title')])
+@extends('profile.layout', ['title' => __('ui.closet.owner_title', ['user' => $user->username])])
 
 @section('profile')
 @if ($items->count() > 0)
@@ -6,16 +6,18 @@
         @foreach ($items as $item)
         <div class="col-lg-4 col-md-6 col-sm-6 p-2">
             @component('items.card', ['item' => $item, 'type' => 'small'])
-                <form action="{{ route('items.closet', $item) }}" method="post">
-                    @csrf
-                    <input type="hidden" name="_method" value="put">
+                @if ($isOwner)
+                    <form action="{{ route('items.closet', $item) }}" method="post">
+                        @csrf
+                        <input type="hidden" name="_method" value="put">
 
-                    <button class="btn btn-outline-danger btn-block rounded-0"
-                        style="border: none; border-top: 1px solid rgba(0, 0, 0, 0.125);"
-                        type="submit">
-                        {{ __('ui.closet.remove') }}
-                    </button>
-                </form>
+                        <button class="btn btn-outline-danger btn-block rounded-0"
+                            style="border: none; border-top: 1px solid rgba(0, 0, 0, 0.125);"
+                            type="submit">
+                            {{ __('ui.closet.remove') }}
+                        </button>
+                    </form>
+                @endif
             @endcomponent
         </div>
         @endforeach
@@ -23,32 +25,38 @@
 
     {{ $items->links() }}
 @else
-<div class="text-center mt-5">
-    <p class="h2">{{ __('ui.closet.empty') }}</p>
-    <p class="lead">@lang('ui.closet.add', ['link' => route('search')])</p>
-</div>
-<div class="row pt-5">
-    <div class="col-4">
-        <div class="card bg-light text-muted">
-            <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
-                <i class="fal fa-plus-circle fa-5x"></i>
+    @if ($isOwner)
+        <div class="text-center mt-5">
+            <p class="h2">{{ __('ui.closet.empty') }}</p>
+            <p class="lead">@lang('ui.closet.add', ['link' => route('search')])</p>
+        </div>
+        <div class="row pt-5">
+            <div class="col-4">
+                <div class="card bg-light text-muted">
+                    <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
+                        <i class="fal fa-plus-circle fa-5x"></i>
+                    </div>
+                </div>
+            </div>
+            <div class="col-4">
+                <div class="card bg-light text-muted">
+                    <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
+                        <i class="fal fa-plus-circle fa-5x"></i>
+                    </div>
+                </div>
+            </div>
+            <div class="col-4">
+                <div class="card bg-light text-muted">
+                    <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
+                        <i class="fal fa-plus-circle fa-5x"></i>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-    <div class="col-4">
-        <div class="card bg-light text-muted">
-            <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
-                <i class="fal fa-plus-circle fa-5x"></i>
-            </div>
+    @else
+        <div class="text-center mt-5">
+            <p class="h2">{{  __('ui.closet.empty_guest', ['user' => $user->username]) }}</p>
         </div>
-    </div>
-    <div class="col-4">
-        <div class="card bg-light text-muted">
-            <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
-                <i class="fal fa-plus-circle fa-5x"></i>
-            </div>
-        </div>
-    </div>
-</div>
+    @endif
 @endif
 @endsection

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -37,6 +37,14 @@
         <input type="password" class="form-control" id="profile-password-confirm" placeholder="{{ __('ui.auth.pw') }}" name="password_confirmation">
         <small class="form-text text-muted">{{ __('ui.auth.pw_no_change') }}</small>
     </div>
+    <div class="form-group form-check">
+        <input type="checkbox" class="form-check-input" name="public_wishlist" id="public-wishlist" value="1" @if ($user->public_wishlist) checked @endif/>
+        <label for="public-wishlist" class="form-check-label">{{ __('ui.auth.public_wishlist') }}</label>
+    </div>
+    <div class="form-group form-check">
+        <input type="checkbox" class="form-check-input" name="public_closet" id="public-closet" value="1" @if ($user->public_closet) checked @endif/>
+        <label for="public-closet" class="form-check-label">{{ __('ui.auth.public_closet') }}</label>
+    </div>
 
     <div class="row">
         <div class="col-sm-6 offset-sm-3 col-md-4 offset-md-4">

--- a/resources/views/profile/layout.blade.php
+++ b/resources/views/profile/layout.blade.php
@@ -7,20 +7,29 @@
             <div class="text-center m-4">
                 <img src="{{ cdn_link('categories/other.svg') }}" alt="" style="max-height: 150px; max-width: 150px" class="img-thumbnail circle">
             </div>
+            <div class="text-center m-4">
+                {{ $user->username }}
+            </div>
 
             <div class="list-group">
-                    <a href="{{ route('profile') }}" class="list-group-item list-group-item-action @if (Route::is('profile')) active @endif">
-                        <i class="fal fa-fw fa-user"></i>
-                        {{ __('ui.profile') }}
-                    </a>
-                    <a href="{{ route('wishlist') }}" class="list-group-item list-group-item-action @if (Route::is('wishlist')) active @endif">
+                    @if ($isOwner)
+                        <a href="{{ route('profile') }}" class="list-group-item list-group-item-action @if (Route::is('profile')) active @endif">
+                            <i class="fal fa-fw fa-user"></i>
+                            {{ __('ui.profile') }}
+                        </a>
+                    @endif
+                    @if ($isOwner || $user->public_wishlist)
+                    <a href="{{ route('public_wishlist', ['username' => $user->username]) }}" class="list-group-item list-group-item-action @if (Route::is('public_wishlist')) active @endif">
                         <i class="fal fa-fw fa-star"></i>
                         {{ __('ui.wishlist.title') }}
                     </a>
-                    <a href="{{ route('closet') }}" class="list-group-item list-group-item-action @if (Route::is('closet')) active @endif">
+                    @endif
+                    @if ($isOwner || $user->public_closet)
+                    <a href="{{ route('public_closet', ['username' => $user->username]) }}" class="list-group-item list-group-item-action @if (Route::is('public_closet')) active @endif">
                         <i class="fal fa-fw fa-tags"></i>
                         {{ __('ui.closet.title') }}
                     </a>
+                    @endif
             </div>
         </div>
         <div class="col-md-8">

--- a/resources/views/profile/wishlist.blade.php
+++ b/resources/views/profile/wishlist.blade.php
@@ -1,4 +1,4 @@
-@extends('profile.layout', ['title' => __('ui.wishlist.title')])
+@extends('profile.layout', ['title' => __('ui.wishlist.owner_title', ['user' => $user->username])])
 
 @section('profile')
 @if ($items->count() > 0)
@@ -6,16 +6,18 @@
         @foreach ($items as $item)
         <div class="col-lg-4 col-md-6 col-sm-6 p-2">
             @component('items.card', ['item' => $item, 'type' => 'small'])
-                <form action="{{ route('items.wishlist', $item) }}" method="post">
-                    @csrf
-                    <input type="hidden" name="_method" value="put">
+                @if ($isOwner)
+                    <form action="{{ route('items.wishlist', $item) }}" method="post">
+                        @csrf
+                        <input type="hidden" name="_method" value="put">
 
-                    <button class="btn btn-outline-danger btn-block rounded-0"
-                        style="border: none; border-top: 1px solid rgba(0, 0, 0, 0.125);"
-                        type="submit">
-                        {{ __('ui.wishlist.remove') }}
-                    </button>
-                </form>
+                        <button class="btn btn-outline-danger btn-block rounded-0"
+                            style="border: none; border-top: 1px solid rgba(0, 0, 0, 0.125);"
+                            type="submit">
+                            {{ __('ui.wishlist.remove') }}
+                        </button>
+                    </form>
+                @endif
             @endcomponent
         </div>
         @endforeach
@@ -23,32 +25,38 @@
 
     {{ $items->links() }}
 @else
-<div class="text-center mt-5">
-    <p class="h2">{{ __('ui.wishlist.empty') }}</p>
-    <p class="lead">@lang('ui.wishlist.add', ['link' => route('search')])</p>
-</div>
-<div class="row pt-5">
-    <div class="col-4">
-        <div class="card bg-light text-muted">
-            <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
-                <i class="fal fa-plus-circle fa-5x"></i>
+    @if ($isOwner)
+        <div class="text-center mt-5">
+            <p class="h2">{{ __('ui.wishlist.empty') }}</p>
+            <p class="lead">@lang('ui.wishlist.add', ['link' => route('search')])</p>
+        </div>
+        <div class="row pt-5">
+            <div class="col-4">
+                <div class="card bg-light text-muted">
+                    <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
+                        <i class="fal fa-plus-circle fa-5x"></i>
+                    </div>
+                </div>
+            </div>
+            <div class="col-4">
+                <div class="card bg-light text-muted">
+                    <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
+                        <i class="fal fa-plus-circle fa-5x"></i>
+                    </div>
+                </div>
+            </div>
+            <div class="col-4">
+                <div class="card bg-light text-muted">
+                    <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
+                        <i class="fal fa-plus-circle fa-5x"></i>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-    <div class="col-4">
-        <div class="card bg-light text-muted">
-            <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
-                <i class="fal fa-plus-circle fa-5x"></i>
-            </div>
+    @else
+        <div class="text-center mt-5">
+            <p class="h2">{{  __('ui.wishlist.empty_guest', ['user' => $user->username]) }}</p>
         </div>
-    </div>
-    <div class="col-4">
-        <div class="card bg-light text-muted">
-            <div class="card-body shadow-sm d-flex justify-content-center align-items-center">
-                <i class="fal fa-plus-circle fa-5x"></i>
-            </div>
-        </div>
-    </div>
-</div>
+    @endif
 @endif
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,9 @@ Route::prefix('profile')->group(function () {
     Route::get('/', 'ProfileController@profile')->name('profile');
     Route::post('/', 'ProfileController@update')->name('update');
     Route::get('closet', 'ProfileController@closet')->name('closet');
+    Route::get('{username}/closet', 'PublicProfileController@closet')->name('public_closet');
     Route::get('wishlist', 'ProfileController@wishlist')->name('wishlist');
+    Route::get('{username}/wishlist', 'PublicProfileController@wishlist')->name('public_wishlist');
 });
 
 // auth endpoint (for mediawiki)


### PR DESCRIPTION
Tests:

1. User is able to toggle the value in the users table using the checkboxes on their profile page
2. A logged out user is able to view a public closet and public wishlist
3. A logged in user is able to view someone else's public closet and wishlist
4. If logged in, the old /profile/wishlist and /profile/closet links redirect to the user's own /profile/<username>/wishlist and /profile/<username>/closet. If logged out, the user is presented with a login screen. After logging in, it will take them to the new URLs.
5. An invalid username for either a profile or closet page generates a 404
6. All closet and wishlist pages display the owner's username on both the page and the title.
7. If viewing someone else's wishlist with a non public closet, the link to their closet will not show up on the left hand navigation.
8. There are no links to remove an item if viewing someone else's closet/wishlist
9. There are no items to add items if viewing someone else's closet/wishlist and that list is empty