### PR TITLE
Updates from feedback

### DIFF
--- a/app/Nova/Item.php
+++ b/app/Nova/Item.php
@@ -80,6 +80,7 @@ class Item extends Resource
             Avatar::make('Image')
                 ->disk('s3public')
                 ->path('images')
+                ->acceptedTypes('.png, .jpeg, .jpg, .webp, .gif, .jfif')
                 ->nullable()
                 ->maxWidth(200),
 

--- a/resources/views/items/show.blade.php
+++ b/resources/views/items/show.blade.php
@@ -23,7 +23,7 @@
                         @include('components.items.closet')
                     </div>
                 </div>                
-                @if (auth()->user() && auth()->user()->senior())
+                @if (auth()->user() && auth()->user()->can('update', $item))
                 <div class="row p-0 mx-0 my-3">
                     <div class="col p-1 list-group text-center small">
                     <a class="btn btn-outline-primary" href="{{ $item->edit_url }}">


### PR DESCRIPTION
- Restrict main item image to the same types as additional images
- Show edit button on items to all users who can edit, not just seniors